### PR TITLE
Split oldest_active_sites by state

### DIFF
--- a/1_fetch/src/get_site_data.R
+++ b/1_fetch/src/get_site_data.R
@@ -1,13 +1,12 @@
 # download data for each site
 # packages needed: tidyverse, dataRetrieval
-get_site_data <- function(sites_info, state, parameter) {
-  site_info <- filter(sites_info, state_cd == state)
+get_site_data <- function(site_info, state, parameter) {
   message(sprintf('  Retrieving data for %s-%s', state, state))
 
   # simulate an unreliable web service or internet connection by causing random failures
   set.seed(Sys.time()) # Make sure that the seed changes with every run (targets likes to store the seed)
   if(runif(1) < 0.5) {
-    Sys.sleep(2)
+    Sys.sleep(0.5)
     stop('Ugh, the internet data transfer failed! Try again.')
   }
 

--- a/_targets.R
+++ b/_targets.R
@@ -12,7 +12,7 @@ source("1_fetch/src/get_site_data.R")
 source("3_visualize/src/map_sites.R")
 
 # Configuration
-states <- c('WI','MN','MI', 'IL')
+states <- c('WI','MN','MI', 'IL', 'IN', 'IA')
 parameter <- c('00060')
 
 # Targets
@@ -20,10 +20,12 @@ list(
   # Identify oldest sites
   tar_target(oldest_active_sites, find_oldest_sites(states, parameter)),
 
-  # TODO: PULL SITE DATA HERE
+  # Pull site data
   tar_map(
     values = tibble(state_abb = states),
-    tar_target(nwis_data, get_site_data(oldest_active_sites, state_abb, parameter))
+    tar_target(nwis_inventory, filter(oldest_active_sites, state_cd == state_abb)),
+  
+    tar_target(nwis_data, get_site_data(nwis_inventory, state_abb, parameter))
     # Insert step for tallying data here
     # Insert step for plotting data here
   ),


### PR DESCRIPTION
Avoid redundant site data downloads by creating `nwis_inventory` branches. These are state-specific rows of `oldest_active_sites`. See #6 

When`IN` and `IA` were added as states, `oldest_active_sites`, `site_map_png`, and all of the `nwis_inventory_XX` branches were rebuilt. However, `nwis_data_XX` was only built for the new states, `IN` and `IA`.