### PR TITLE
Combiners

### DIFF
--- a/2_process/src/summarize_targets.R
+++ b/2_process/src/summarize_targets.R
@@ -1,0 +1,8 @@
+summarize_targets <- function(ind_file, ...) {
+  ind_tbl <- tar_meta(c(...)) %>% 
+    select(tar_name = name, filepath = path, hash = data) %>% 
+    mutate(filepath = unlist(filepath))
+  
+  readr::write_csv(ind_tbl, ind_file)
+  return(ind_file)
+}

--- a/2_process/src/tally_site_obs.R
+++ b/2_process/src/tally_site_obs.R
@@ -9,3 +9,8 @@ tally_site_obs <- function(site_data) {
     group_by(Site, State, Year) %>%
     summarize(NumObs = length(which(!is.na(Value))), .groups = "keep")
 }
+
+combine_obs_tallies <- function(...) {
+  # combine input tally tibbles
+  return(bind_rows(...))
+}

--- a/3_visualize/log/summary_state_timeseries.csv
+++ b/3_visualize/log/summary_state_timeseries.csv
@@ -1,6 +1,7 @@
 tar_name,filepath,hash
-timeseries_png_WI,3_visualize/out/timeseries_WI.png,15fd91e6a764e2fc
-timeseries_png_MN,3_visualize/out/timeseries_MN.png,6b63e160c27247f7
-timeseries_png_MI,3_visualize/out/timeseries_MI.png,a8f6cab61f13fc3b
-timeseries_png_IL,3_visualize/out/timeseries_IL.png,9eea60e4a4c275fd
-timeseries_png_IN,3_visualize/out/timeseries_IN.png,9d1deb7a9ab7bb73
+timeseries_png_WI,3_visualize/out/timeseries_WI.png,4c142d38c3c08f6c
+timeseries_png_MN,3_visualize/out/timeseries_MN.png,fb4123f2ad9e4c2d
+timeseries_png_MI,3_visualize/out/timeseries_MI.png,785536af88f00119
+timeseries_png_IL,3_visualize/out/timeseries_IL.png,e1a824d51490af54
+timeseries_png_IN,3_visualize/out/timeseries_IN.png,782361416d08b715
+timeseries_png_IA,3_visualize/out/timeseries_IA.png,274a062a16c9063e

--- a/3_visualize/log/summary_state_timeseries.csv
+++ b/3_visualize/log/summary_state_timeseries.csv
@@ -1,0 +1,6 @@
+tar_name,filepath,hash
+timeseries_png_WI,3_visualize/out/timeseries_WI.png,15fd91e6a764e2fc
+timeseries_png_MN,3_visualize/out/timeseries_MN.png,6b63e160c27247f7
+timeseries_png_MI,3_visualize/out/timeseries_MI.png,a8f6cab61f13fc3b
+timeseries_png_IL,3_visualize/out/timeseries_IL.png,9eea60e4a4c275fd
+timeseries_png_IN,3_visualize/out/timeseries_IN.png,9d1deb7a9ab7bb73

--- a/_targets.R
+++ b/_targets.R
@@ -6,7 +6,8 @@ suppressPackageStartupMessages(library(dplyr))
 
 options(tidyverse.quiet = TRUE)
 tar_option_set(packages = c("tidyverse", "dataRetrieval", "urbnmapr",
-                            "rnaturalearth", "cowplot", "lubridate"))
+                            "rnaturalearth", "cowplot", "lubridate",
+                            "leaflet", "leafpop", "htmlwidgets"))
 
 # Load functions needed by targets below
 source("1_fetch/src/find_oldest_sites.R")
@@ -16,10 +17,11 @@ source("2_process/src/summarize_targets.R")
 source("3_visualize/src/map_sites.R")
 source("3_visualize/src/plot_site_data.R")
 source("3_visualize/src/plot_data_coverage.R")
+source("3_visualize/src/map_timeseries.R")
 
 # Configuration
-states <- c('WI','MN','MI', 'IL', 'IN')
-# states <- c('WI','MN','MI', 'IL', 'IN', 'IA')
+# states <- c('WI','MN','MI', 'IL', 'IN')
+states <- c('WI','MN','MI', 'IL', 'IN', 'IA')
 parameter <- c('00060')
 
 # Pull site data
@@ -49,20 +51,22 @@ list(
   # Combine tallies
   tar_combine(obs_tallies, mapped_by_state_targets[[3]], command = combine_obs_tallies(!!!.x)),
   # Summarize targets
-  tar_combine(
-    summary_state_timeseries_csv,
-    mapped_by_state_targets[[4]],
-    command = summarize_targets('3_visualize/log/summary_state_timeseries.csv', !!!.x),
-    format="file"
-  ),
+  tar_combine(summary_state_timeseries_csv, 
+              mapped_by_state_targets[[4]], 
+              command = summarize_targets('3_visualize/log/summary_state_timeseries.csv', !!!.x), 
+              format="file"),
   # Plot data coverage
   tar_target(data_coverage_png, 
              plot_data_coverage(obs_tallies, "3_visualize/out/data_coverage.png", parameter),
              format = "file"),
   # Map oldest sites
-  tar_target(
-    site_map_png,
-    map_sites("3_visualize/out/site_map.png", oldest_active_sites),
-    format = "file"
-  )
+  tar_target(site_map_png, 
+             map_sites("3_visualize/out/site_map.png", oldest_active_sites), 
+             format = "file"),
+  # Interactive map of oldest sites, with timeseries plots
+  tar_target(timeseries_map_html,
+             map_timeseries(site_info = oldest_active_sites,
+                            plot_info_csv = summary_state_timeseries_csv,
+                            out_file = "3_visualize/out/timeseries_map.html"),
+             format = "file")
 )

--- a/_targets.R
+++ b/_targets.R
@@ -14,31 +14,41 @@ source("1_fetch/src/get_site_data.R")
 source("2_process/src/tally_site_obs.R")
 source("3_visualize/src/map_sites.R")
 source("3_visualize/src/plot_site_data.R")
+source("3_visualize/src/plot_data_coverage.R")
 
 # Configuration
-states <- c('WI','MN','MI', 'IL', 'IN', 'IA')
+states <- c('WI','MN','MI', 'IL', 'IN')
+# states <- c('WI','MN','MI', 'IL', 'IN', 'IA')
 parameter <- c('00060')
+
+# Pull site data
+mapped_by_state_targets <- tar_map(
+  values = tibble(state_abb = states) %>% 
+    mutate(state_plot_files = sprintf("3_visualize/out/timeseries_%s.png", state_abb)),
+  names = state_abb,
+  unlist = FALSE,
+  # split oldest_active_sites by state
+  tar_target(nwis_inventory, filter(oldest_active_sites, state_cd == state_abb)),
+  # download site data
+  tar_target(nwis_data, get_site_data(nwis_inventory, state_abb, parameter)),
+  # tally data
+  tar_target(tally, tally_site_obs(nwis_data)),
+  # plot data
+  tar_target(timeseries_png, plot_site_data(state_plot_files, nwis_data, parameter))
+)
 
 # Targets
 list(
   # Identify oldest sites
   tar_target(oldest_active_sites, find_oldest_sites(states, parameter)),
-
-  # Pull site data
-  tar_map(
-    values = tibble(state_abb = states) %>% 
-      mutate(state_plot_files = sprintf("3_visualize/out/timeseries_%s.png", state_abb)),
-    names = state_abb,
-    # split oldest_active_sites by state
-    tar_target(nwis_inventory, filter(oldest_active_sites, state_cd == state_abb)),
-    # download site data
-    tar_target(nwis_data, get_site_data(nwis_inventory, state_abb, parameter)),
-    # tally data
-    tar_target(tally, tally_site_obs(nwis_data)),
-    # plot data
-    tar_target(timeseries_png, plot_site_data(state_plot_files, nwis_data, parameter))
-  ),
-
+  # Pull site data, tally, and plot
+  mapped_by_state_targets,
+  # Combine tallies
+  tar_combine(obs_tallies, mapped_by_state_targets[[3]], command = combine_obs_tallies(!!!.x)),
+  # Plot data coverage
+  tar_target(data_coverage_png, 
+             plot_data_coverage(obs_tallies, "3_visualize/out/data_coverage.png", parameter),
+             format = "file"),
   # Map oldest sites
   tar_target(
     site_map_png,

--- a/_targets.R
+++ b/_targets.R
@@ -12,6 +12,7 @@ tar_option_set(packages = c("tidyverse", "dataRetrieval", "urbnmapr",
 source("1_fetch/src/find_oldest_sites.R")
 source("1_fetch/src/get_site_data.R")
 source("2_process/src/tally_site_obs.R")
+source("2_process/src/summarize_targets.R")
 source("3_visualize/src/map_sites.R")
 source("3_visualize/src/plot_site_data.R")
 source("3_visualize/src/plot_data_coverage.R")
@@ -34,7 +35,9 @@ mapped_by_state_targets <- tar_map(
   # tally data
   tar_target(tally, tally_site_obs(nwis_data)),
   # plot data
-  tar_target(timeseries_png, plot_site_data(state_plot_files, nwis_data, parameter))
+  tar_target(timeseries_png,
+             plot_site_data(state_plot_files, nwis_data, parameter),
+             format = "file")
 )
 
 # Targets
@@ -45,6 +48,13 @@ list(
   mapped_by_state_targets,
   # Combine tallies
   tar_combine(obs_tallies, mapped_by_state_targets[[3]], command = combine_obs_tallies(!!!.x)),
+  # Summarize targets
+  tar_combine(
+    summary_state_timeseries_csv,
+    mapped_by_state_targets[[4]],
+    command = summarize_targets('3_visualize/log/summary_state_timeseries.csv', !!!.x),
+    format="file"
+  ),
   # Plot data coverage
   tar_target(data_coverage_png, 
              plot_data_coverage(obs_tallies, "3_visualize/out/data_coverage.png", parameter),


### PR DESCRIPTION
- Using `tar_combine()`, ombine tallies of observations per year, and use them to plot data coverage through time.
- Summarize time series plots of discharge at oldest sites to track changes.
- Create an interactive map showing site locations and time series plots.

Here's a screenshot of the interactive plot:

<img width="1148" alt="Screen Shot 2021-09-27 at 4 04 15 PM" src="https://user-images.githubusercontent.com/11847289/134992018-1e142cbb-e1fa-4013-bce1-b3fb3386f54b.png">

There's one odd behavior: if I add/remove a state, sometimes every target gets rebuilt. If I add/remove a state again right away, though, then only the expected targets are remade. It doesn't seem to matter whether I'm adding or removing a state. It seems like this should only happen when the `nwis_inventory_XX` targets change, so I'm not sure why this happens. 

See #10 